### PR TITLE
Reduce duplication of hard-coded org names

### DIFF
--- a/modules/component/Makefile
+++ b/modules/component/Makefile
@@ -10,7 +10,7 @@ COMPONENT_VERSION ?= $(shell cat COMPONENT_VERSION 2> /dev/null)
 COMPONENT_TAG_EXTENSION ?= -${PULL_BASE_SHA}
 
 # Build the details for the remote destination repo for the image
-COMPONENT_DOCKER_REPO ?= quay.io/open-cluster-management
+COMPONENT_DOCKER_REPO ?= quay.io/${PIPELINE_MANIFEST_QUAY_ORG}
 
 # Variables Requred by different component types:
 #---helmoperator---#

--- a/modules/osci/Makefile
+++ b/modules/osci/Makefile
@@ -18,7 +18,7 @@ OSCI_RELEASE_VERSION ?= $(subst release-,,$(OSCI_COMPONENT_BRANCH))
 OSCI_RELEASE_SHA_VERSION ?= $(OSCI_RELEASE_VERSION)
 
 OSCI_PIPELINE_SITE ?= github.com
-OSCI_PIPELINE_ORG ?= open-cluster-management
+OSCI_PIPELINE_ORG ?= $(PIPELINE_MANIFEST_ORG)
 OSCI_PIPELINE_REPO ?= pipeline
 OSCI_PIPELINE_STAGE ?= integration
 OSCI_PIPELINE_RETAG_BRANCH ?= quay-retag
@@ -34,7 +34,7 @@ OSCI_IMAGE_ALIAS_BASENAME ?= image-alias
 OSCI_IMAGE_ALIAS_FILENAME ?= $(OSCI_IMAGE_ALIAS_BASENAME).json
 OSCI_MANIFEST_SNAPSHOT_DIR ?= snapshots
 
-OSCI_IMAGE_REMOTE_REPO ?= quay.io/open-cluster-management
+OSCI_IMAGE_REMOTE_REPO ?= $(PIPELINE_MANIFEST_REMOTE_REPO)
 OSCI_IMAGE_REMOTE_REPO_SRC ?= $(OSCI_IMAGE_REMOTE_REPO)
 OSCI_IMAGE_REMOTE_REPO_DST ?= $(OSCI_IMAGE_REMOTE_REPO)
 
@@ -52,7 +52,7 @@ OSCI_SORT_QUERY ?= . | sort_by(.["image-name"])
 
 OSCI_DATETIME := $(shell (date +%Y-%m-%d-%H-%M-%S))
 
-OSCI_Z_RELEASE_VERSION ?= $(shell curl -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/open-cluster-management/release/${OSCI_COMPONENT_BRANCH}/Z_RELEASE_VERSION)
+OSCI_Z_RELEASE_VERSION ?= $(shell curl -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/$(OSCI_PIPELINE_ORG)/release/${OSCI_COMPONENT_BRANCH}/Z_RELEASE_VERSION)
 
 
 .PHONY: osci/_datetime_gen

--- a/modules/pipeline-manifest/Makefile
+++ b/modules/pipeline-manifest/Makefile
@@ -14,12 +14,14 @@ PIPELINE_MANIFEST_SITE ?= github.com
 PIPELINE_MANIFEST_ORG ?= open-cluster-management
 # Repo name not yet confirmed
 PIPELINE_MANIFEST_REPO ?= pipeline
+# The "product" name that is used for release repo; release=RHACM, backplane=backplane
+PIPELINE_PRODUCT_PREFIX ?= release
 # The URL for the pipeline repo
 PIPELINE_MANIFEST_GIT_URL ?= "https://$(GITHUB_USER):$(GITHUB_TOKEN)@$(PIPELINE_MANIFEST_SITE)/$(PIPELINE_MANIFEST_ORG)/$(PIPELINE_MANIFEST_REPO).git"
 # Branch of release component is on, i.e release-1.0.0
 PIPELINE_MANIFEST_COMPONENT_BRANCH ?= $(PIPELINE_MANIFEST_BRANCH)
 # Release version of the product
-PIPELINE_MANIFEST_RELEASE_VERSION ?= $(subst release-,,$(PIPELINE_MANIFEST_BRANCH))
+PIPELINE_MANIFEST_RELEASE_VERSION ?= $(subst $(PIPELINE_PRODUCT_PREFIX)-,,$(PIPELINE_MANIFEST_BRANCH))
 # Release version of the product based on the branch it came from
 PIPELINE_MANIFEST_SHA_RELEASE_VERSION ?= $(PIPELINE_MANIFEST_RELEASE_VERSION)
 # Directory to put manifest in
@@ -39,9 +41,11 @@ PIPELINE_MANIFEST_RETAG_BRANCH ?= quay-retag
 PIPELINE_MANIFEST_LATEST_BRANCH ?= 2.0-edge
 # The Z release of the pipeline to use for grabbing the latest manifest file
 PIPELINE_MANIFEST_LATEST_Z_RELEASE ?= 2.0.0
-PIPELINE_MANIFEST_REMOTE_REPO ?= quay.io/open-cluster-management
+# If GitHub and Quay org names diverge, this is where it changes
+PIPELINE_MANIFEST_QUAY_ORG ?= $(PIPELINE_MANIFEST_ORG)
+PIPELINE_MANIFEST_REMOTE_REPO ?= quay.io/$(PIPELINE_MANIFEST_QUAY_ORG)
 PIPELINE_MANIFEST_REMOTE_REPO_SRC ?= $(PIPELINE_MANIFEST_REMOTE_REPO)
-PIPELINE_MANIFEST_REMOTE_REPO_DST ?= quay.io/open-cluster-management
+PIPELINE_MANIFEST_REMOTE_REPO_DST ?= quay.io/$(PIPELINE_MANIFEST_QUAY_ORG)
 
 PIPELINE_MANIFEST_COMPONENT_SUFFIX ?= $(PIPELINE_MANIFEST_COMPONENT_SHA256)
 
@@ -67,8 +71,8 @@ PIPELINE_MANIFEST_GIT_BRANCH ?= $(PIPELINE_MANIFEST_RELEASE_VERSION)-$(PROMOTE_F
 PIPELINE_MANIFEST_RETAG_REPO ?= quay
 
 DATETIME_VAR := $(shell (date +%Y-%m-%d-%H-%M-%S))
-Z_RELEASE_VERSION ?= $(shell curl -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/open-cluster-management/release/${PIPELINE_MANIFEST_BRANCH}/Z_RELEASE_VERSION)
-	
+Z_RELEASE_VERSION ?= $(shell curl -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.raw" https://raw.githubusercontent.com/${PIPELINE_MANIFEST_ORG}/release/${PIPELINE_MANIFEST_BRANCH}/Z_RELEASE_VERSION)
+
 
 .PHONY: pipeline-manifest/_datetime_gen
 # Factory method for storing datetime variable
@@ -258,8 +262,8 @@ pipeline-manifest/_validate-tag: %_validate-tag:
 .PHONY: pipeline-manifest/_retag
 # Validate and retag all images or git repos identified in manifest
 pipeline-manifest/_retag: %_retag:
-	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) true $(PIPELINE_MANIFEST_RETAG_REPO) $(PIPELINE_MANIFEST_SHA_RELEASE_VERSION)
-	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) false $(PIPELINE_MANIFEST_RETAG_REPO) $(PIPELINE_MANIFEST_SHA_RELEASE_VERSION)
+	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) true $(PIPELINE_MANIFEST_RETAG_REPO) $(PIPELINE_MANIFEST_SHA_RELEASE_VERSION) $(PIPELINE_MANIFEST_REPO) $(PIPELINE_MANIFEST_ORG) $(PIPELINE_PRODUCT_PREFIX)
+	@python3 $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/pipeline-manifest/bin/parser.py $(PIPELINE_MANIFEST_FILE_NAME).json $(TAG) false $(PIPELINE_MANIFEST_RETAG_REPO) $(PIPELINE_MANIFEST_SHA_RELEASE_VERSION) $(PIPELINE_MANIFEST_REPO) $(PIPELINE_MANIFEST_ORG) $(PIPELINE_PRODUCT_PREFIX)
 
 .PHONY: pipeline-manifest/_get_latest_manifest
 # Get the latest manifest file in the snapshots directory of the pipeline repo on the PIPELINE_MANIFEST_LATEST_BRANCH branch (i.e. x.y-edge or x.y-stable) specific to a Z-release

--- a/modules/pipeline-manifest/bin/parser.py
+++ b/modules/pipeline-manifest/bin/parser.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+import re
 from subprocess import run
 
 # Parameters:
@@ -8,6 +9,15 @@ from subprocess import run
 #  sys.argv[2] - textual tag
 #  sys.argv[3] - boolean: dry run/validate (true) vs. actually do the tagging (false)
 #  sys.argv[4] - textual name of repo to do the tagging in (git|quay)
+#  sys.argv[5] - z-release "name" (i.e. 2.0.1)
+#  sys.argv[6] - PIPELINE_MANIFEST_REPO (pipelie|backplane-pipeline)
+#  sys.argv[7] - PIPELINE_MANIFEST_ORG
+#  sys.argv[8] - "product" name (release|backplane)
+
+if sys.argv[8] == "backplane":
+    tag_discriminator="-BACKPLANE-"
+else:
+    tag_discriminator="-SNAPSHOT-"
 
 data = json.load(open(sys.argv[1]))
 for v in data:
@@ -17,17 +27,19 @@ for v in data:
     compenent_sha = v["git-sha256"]
     component_repo = v["git-repository"]
     component_version = v["image-tag"].replace('-'+v["git-sha256"],'')
-    if (sys.argv[2].startswith('20')):
-        # Assuming a date is coming in as a tag, mark it all up with SNAPSHOT decoration specifc to this repo
-        retag_name = component_version + "-SNAPSHOT-" + sys.argv[2]
+    date_re=r"^\d{4}(-\d\d){5}$"
+    if re.search(date_re,sys.argv[2]):
+        # Assuming a date such as "2020-xx-yy..." is coming in as a tag, mark it all up with SNAPSHOT decoration specifc to this repo:
+        # z-release name + tag_discriminator + tag (i.e. snapshot date/timestamp)
+        retag_name = sys.argv[5] + tag_discriminator + sys.argv[2]
     else:
         # Tag is respected as literally and solely the second argument contents, likely a version/release tag
         retag_name = sys.argv[2]
-    if (component_repo.startswith('open-cluster-management')):
+    if (component_repo.startswith(sys.argv[7])):
         # We don't try to tag anyone else's repos
         run('echo RETAG_SNAPSHOT_NAME={} COMPONENT_NAME={} RETAG_REPO={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={} repo-type={}'.format(retag_name, component_name, component_repo, compenent_tag, compenent_sha, sys.argv[3], sys.argv[4]), shell=True)
         if (sys.argv[4] == "git"):
-            if (component_name != "origin-oauth-proxy"):
+            if ((component_name != "origin-oauth-proxy") & (component_name != "grafana")):
                 run('make retag/git RETAG_SNAPSHOT_NAME={} RETAG_REPO={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={}'.format(retag_name, component_repo, compenent_tag, compenent_sha, sys.argv[3]), shell=True, check=True)
         elif (sys.argv[4] == "quay"):
             run('make retag/quay RETAG_SNAPSHOT_NAME={} COMPONENT_NAME={} RETAG_QUAY_COMPONENT_TAG={} RETAG_GITHUB_SHA={} RETAG_DRY_RUN={}'.format(retag_name, component_name, compenent_tag, compenent_sha, sys.argv[3]), shell=True, check=True)

--- a/modules/retag/Makefile
+++ b/modules/retag/Makefile
@@ -14,7 +14,6 @@ RETAG_QUAY_COMPONENT_TAG ?=
 RETAG_SNAPSHOT_NAME ?=
 RETAG_GITHUB_SHA ?=
 RETAG_REPO ?=
-PIPELINE_MANIFEST_ORG ?= open-cluster-management
 
 # Retag needs to do the following steps:
 #  1. Find an image in quay based on what we would call the team's docker tag, and pull out and assign 'RETAG_QUAY_SHA' from that
@@ -62,7 +61,7 @@ retag/getquaysha: %getquaysha:
 retag/shabuild: %shabuild:
 	@$(shell $(SELF) jq/install > /dev/null)
 	@$(shell $(SELF) yq/install > /dev/null)
-	$(GIT) clone -b $(RETAG_GIT_BRANCH) https://github.com/open-cluster-management/multicloudhub-repo.git
-	$(shell $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/retag/bin/process.sh multicloudhub-repo/multiclusterhub/charts ${RETAG_SNAPSHOT_NAME} > temp.out )
+	$(GIT) clone -b $(RETAG_GIT_BRANCH) https://github.com/$(PIPELINE_MANIFEST_ORG)/multicloudhub-repo.git
+	$(shell $(BUILD_HARNESS_EXTENSIONS_PATH)/modules/retag/bin/process.sh multicloudhub-repo/multiclusterhub/charts ${RETAG_SNAPSHOT_NAME} ${PIPELINE_MANIFEST_QUAY_ORG} > temp.out )
 	@cat temp.out
 

--- a/modules/retag/bin/process.sh
+++ b/modules/retag/bin/process.sh
@@ -3,12 +3,13 @@
 # Incoming parameters:
 #   $1 - path to the charts that should be manipulated (typically multicloudhub-repo/multiclusterhub/charts)
 #   $2 - snapshot date (just the date part)
+#   $3 - Quay org name
 #
 # Required environment variables:
-#   $QUAY_TOKEN - you know, the token... to quay (needs to be able to read open-cluster-management stuffs
+#   $QUAY_TOKEN - you know, the token... to quay (needs to be able to read quay org stuffs
 #
 
-quay_org=open-cluster-management
+quay_org=$3
 
 SNAPSHOT=$2
 if [[ -z "$GITHUB_TOKEN" ]]


### PR DESCRIPTION
Similar changes in the main build-harness-extensions - focusing on having modules/pipeline-manifest be the single source of GitHub and Quay org names.